### PR TITLE
feat: add support for upsert entities with update mode

### DIFF
--- a/lib/config/detekt/baseline.xml
+++ b/lib/config/detekt/baseline.xml
@@ -3,6 +3,7 @@
   <ManuallySuppressedIssues></ManuallySuppressedIssues>
   <CurrentIssues>
     <ID>LongParameterList:BatchEntityService.kt$BatchEntityService$( brokerUrl: String, authServerUrl: String, authClientId: String, authClientSecret: String, authGrantType: String, payload: String )</ID>
+    <ID>LongParameterList:BatchEntityService.kt$BatchEntityService$( brokerUrl: String, authServerUrl: String, authClientId: String, authClientSecret: String, authGrantType: String, payload: String, queryParams: Map&lt;String, String&gt; )</ID>
     <ID>LongParameterList:EntityService.kt$EntityService$( brokerUrl: String, authServerUrl: String, authClientId: String, authClientSecret: String, authGrantType: String, entityId: URI, attributesPayload: String, contextUrl: String )</ID>
     <ID>LongParameterList:EntityService.kt$EntityService$( brokerUrl: String, authServerUrl: String, authClientId: String, authClientSecret: String, authGrantType: String, entityPayload: String )</ID>
     <ID>LongParameterList:EntityService.kt$EntityService$( brokerUrl: String, authServerUrl: String, authClientId: String, authClientSecret: String, authGrantType: String, queryParams: Map&lt;String, String&gt;, contextUrl: String )</ID>

--- a/lib/src/main/kotlin/io/egm/kngsild/api/BatchEntityService.kt
+++ b/lib/src/main/kotlin/io/egm/kngsild/api/BatchEntityService.kt
@@ -7,6 +7,7 @@ import arrow.core.right
 import io.egm.kngsild.model.ApplicationError
 import io.egm.kngsild.model.ContextBrokerError
 import io.egm.kngsild.utils.AuthUtils
+import io.egm.kngsild.utils.HttpUtils
 import io.egm.kngsild.utils.HttpUtils.APPLICATION_JSON
 import io.egm.kngsild.utils.HttpUtils.APPLICATION_JSONLD
 import io.egm.kngsild.utils.HttpUtils.httpClient
@@ -75,11 +76,13 @@ class BatchEntityService(
         authClientId: String,
         authClientSecret: String,
         authGrantType: String,
-        payload: String
+        payload: String,
+        queryParams: Map<String, String>
     ): Either<ApplicationError, HttpResponse<String>> {
+        val params: String = HttpUtils.paramsUrlBuilder(queryParams)
         return authUtils.getToken(authServerUrl, authClientId, authClientSecret, authGrantType).flatMap {
             val request = HttpRequest.newBuilder().uri(
-                URI.create("$brokerUrl/ngsi-ld/v1/entityOperations/upsert")
+                URI.create("$brokerUrl/ngsi-ld/v1/entityOperations/upsert$params")
             )
                 .setHeader("Content-Type", APPLICATION_JSONLD)
                 .setHeader("Authorization", "Bearer $it")

--- a/lib/src/test/kotlin/io/egm/kngsild/api/BatchEntityServiceTest.kt
+++ b/lib/src/test/kotlin/io/egm/kngsild/api/BatchEntityServiceTest.kt
@@ -179,7 +179,8 @@ class BatchEntityServiceTest {
             "client_id",
             "client_secret",
             "client_credentials",
-            batchEntityPayload
+            batchEntityPayload,
+            emptyMap()
         )
 
         assertTrue(response.isRight())
@@ -213,7 +214,8 @@ class BatchEntityServiceTest {
             "client_id",
             "client_secret",
             "client_credentials",
-            batchEntityPayload
+            batchEntityPayload,
+            emptyMap()
         )
 
         assertTrue(response.isLeft())
@@ -241,7 +243,8 @@ class BatchEntityServiceTest {
             "client_id",
             "client_secret",
             "client_credentials",
-            batchEntityPayload
+            batchEntityPayload,
+            emptyMap()
         )
 
         assertTrue(response.isLeft())


### PR DESCRIPTION
I was not able to test an endpoint that takes query params (for instance, the options param, in upsert endpoint). I think it's related to [this](https://github.com/tomakehurst/wiremock/issues/1262) issue in wiremock. 